### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@ galaxy_info:
         - 6
         - 7
         - 8
+        - 9
     - name: Fedora
       versions:
         - all

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -1,0 +1,8 @@
+---
+# This system supports drop in directory so defaults are adjusted
+__ssh_supports_drop_in: true
+ssh_drop_in_name: "00-ansible"
+
+# This default lists the main configuration file defaults
+__ssh_defaults:
+  Include: /etc/ssh/ssh_config.d/*.conf


### PR DESCRIPTION
The rhel-8-y status is the latest unreleased RHEL-8 and the rhel-x status is pre-released RHEL-9.