### PR TITLE
Drop support for Ansible 2.8 by bumping the Ansible version to 2.9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: OpenSSH SSH client configuration
   company: Red Hat Inc.
   license: LGPGv3
-  min_ansible_version: 2.8
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Bug 1989197 - drop support for Ansible 2.8
https://bugzilla.redhat.com/show_bug.cgi?id=1989197