### PR TITLE
update tox-lsr version to 2.8.0

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.7.1"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.8.0"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default


### PR DESCRIPTION
New version adds check for proper commenting of the ansible_managed var