### PR TITLE
support gather_facts: false; support setup-snapshot.yml (#52)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,6 @@
 ---
 - name: Set platform/version specific variables
-  include_vars: "{{ __ssh_vars_file }}"
-  loop:
-    - "{{ ansible_facts['os_family'] }}.yml"
-    - "{{ ansible_facts['distribution'] }}.yml"
-    - >-
-      {{ ansible_facts['distribution'] ~ '_' ~
-      ansible_facts['distribution_major_version'] }}.yml
-    - >-
-      {{ ansible_facts['distribution'] ~ '_' ~
-      ansible_facts['distribution_version'] }}.yml
-  vars:
-    __ssh_vars_file: "{{ role_path }}/vars/{{ item }}"
-  when: __ssh_vars_file is file
+  include_tasks: tasks/set_vars.yml
 
 - name: Ensure required packages are installed
   package:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,21 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__ssh_required_facts) == __ssh_required_facts
+
+- name: Set platform/version specific variables
+  include_vars: "{{ __vars_file }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_major_version'] }}.yml
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_version'] }}.yml
+  vars:
+    __vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __vars_file is file

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.ssh
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ __ssh_packages }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -13,6 +13,7 @@
   hosts: all
   roles:
     - linux-system-roles.ssh
+  gather_facts: false
 
 - hosts: all
   vars:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,3 +11,10 @@ __ssh_supports_validate: true
 
 # The default options found in the main configuration file
 __ssh_defaults: {}
+
+# ansible_facts required by the role
+__ssh_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.