### PR TITLE
Update CI and docs

### DIFF
--- a/.github/workflows/ansible-ubuntu.yml
+++ b/.github/workflows/ansible-ubuntu.yml
@@ -8,13 +8,11 @@ jobs:
   ubuntu-latest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: checkout PR
+        uses: actions/checkout@v2
 
       - name: ansible check with ubuntu:latest
-        # the upstream is broken:
-        # https://github.com/roles-ansible/check-ansible-ubuntu-latest-action/pull/2
-        # uses: roles-ansible/check-ansible-ubuntu-latest-action@master
-        uses: Jakuje/check-ansible-ubuntu-latest-action@patch-1
+        uses: roles-ansible/check-ansible-ubuntu-latest-action@master
         with:
           group: local
           hosts: localhost
@@ -27,10 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: ansible check with ubuntu:20 (focal)
-        # the upstream is broken:
-        # https://github.com/roles-ansible/check-ansible-ubuntu-focal-action/pull/2
-        # uses: roles-ansible/check-ansible-ubuntu-focal-action@master
-        uses: Jakuje/check-ansible-ubuntu-focal-action@patch-1
+        uses: roles-ansible/check-ansible-ubuntu-focal-action@master
         with:
           group: local
           hosts: localhost

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ssh
 ![CI Testing](https://github.com/linux-system-roles/ssh/workflows/tox/badge.svg)
+[![CI Ubuntu](https://github.com/linux-system-roles/ssh/actions/workflows/ansible-ubuntu.yml/badge.svg)](https://github.com/linux-system-roles/ssh/actions/workflows/ansible-ubuntu.yml)
+[![CI Debian](https://github.com/linux-system-roles/ssh/actions/workflows/ansible-debian.yml/badge.svg)](https://github.com/linux-system-roles/ssh/actions/workflows/ansible-debian.yml)
 
 An Ansible role for managing ssh clients configuration.
 
@@ -8,8 +10,8 @@ An Ansible role for managing ssh clients configuration.
 This role should work on any system that provides openssh client and is
 supported by ansible. The role was tested on:
 
- * RHEL/CentOS 6, 7, 8
- * Fedora 32, 33
+ * RHEL/CentOS 6, 7, 8, 9
+ * Fedora
  * Debian
  * Ubuntu
 
@@ -121,4 +123,4 @@ LGPLv3, see the file LICENSE for more information.
 
 ## Author Information
 
-Jakub Jelen, 2021
+Jakub Jelen, 2021 - 2022

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,6 +28,7 @@ galaxy_info:
         - xenial
         - bionic
         - focal
+        - jammy
   galaxy_tags:
     - networking
     - system


### PR DESCRIPTION
The PRs for CI are already merged so revert back to the upstream version of the actions. Update also relevancy in meta, readme and ads CI badges.