### PR TITLE
cast value to string in jinja macro

### DIFF
--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -7,7 +7,7 @@
 {%     elif value is sameas false %}
 {{ key }} no
 {%     elif value is string or value is number %}
-{{ key }} {{ value }}
+{{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
 {{ key }} {{ i }}

--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -10,7 +10,7 @@
 {{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
-{{ key }} {{ i }}
+{{ key }} {{ i | string }}
 {%       endfor %}
 {%     endif %}
 {%   endif %}


### PR DESCRIPTION
Some versions of jinja will not automatically convert values to
string in a `{{ ... }}` block, so use `| string` to ensure that
it is converted to string.
