### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/.dev-tools/10_top.j2
+++ b/.dev-tools/10_top.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:ssh" | comment(prefix="", postfix="") }}
 {% macro render_option(key, value, indent=false) %}
 {%   if value is defined %}
 {%     if indent %}  {% endif %}

--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:ssh" | comment(prefix="", postfix="") }}
 {% macro render_option(key, value, indent=false) %}
 {%   if value is defined %}
 {%     if indent %}  {% endif %}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:ssh
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.