### PR TITLE
Proper indent when lists are used in block

### DIFF
--- a/.dev-tools/10_top.j2
+++ b/.dev-tools/10_top.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:ssh" | comment(prefix="", postfix="") }}
 {% macro render_option(key, value, indent=false) %}
 {%   if value is defined %}
 {%     if indent %}  {% endif %}

--- a/.dev-tools/10_top.j2
+++ b/.dev-tools/10_top.j2
@@ -2,15 +2,18 @@
 {{ "system_role:ssh" | comment(prefix="", postfix="") }}
 {% macro render_option(key, value, indent=false) %}
 {%   if value is defined %}
-{%     if indent %}  {% endif %}
 {%     if value is sameas true %}
+{%       if indent %}  {% endif %}
 {{ key }} yes
 {%     elif value is sameas false %}
+{%       if indent %}  {% endif %}
 {{ key }} no
 {%     elif value is string or value is number %}
+{%       if indent %}  {% endif %}
 {{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
+{%         if indent %}  {% endif %}
 {{ key }} {{ i | string }}
 {%       endfor %}
 {%     endif %}

--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:ssh" | comment(prefix="", postfix="") }}
 {% macro render_option(key, value, indent=false) %}
 {%   if value is defined %}
 {%     if indent %}  {% endif %}

--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -2,15 +2,18 @@
 {{ "system_role:ssh" | comment(prefix="", postfix="") }}
 {% macro render_option(key, value, indent=false) %}
 {%   if value is defined %}
-{%     if indent %}  {% endif %}
 {%     if value is sameas true %}
+{%       if indent %}  {% endif %}
 {{ key }} yes
 {%     elif value is sameas false %}
+{%       if indent %}  {% endif %}
 {{ key }} no
 {%     elif value is string or value is number %}
+{%       if indent %}  {% endif %}
 {{ key }} {{ value | string }}
 {%     else %}
 {%       for i in value %}
+{%         if indent %}  {% endif %}
 {{ key }} {{ i | string }}
 {%       endfor %}
 {%     endif %}


### PR DESCRIPTION
Only the first list item was properly indented. In case of the RHEL7 default config the indent was like

```config
#
# Ansible managed
#
Host *
  ForwardX11Trusted yes
  GSSAPIAuthentication yes
  SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE
SendEnv XMODIFIERS
```

this is now fixed. I.e. the default results in 

```config
#
# Ansible managed
#
# system_role:ssh

Host *
  ForwardX11Trusted yes
  GSSAPIAuthentication yes
  SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
  SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
  SendEnv LC_IDENTIFICATION LC_ALL LANGUAGE
  SendEnv XMODIFIERS
```