### PR TITLE
add vars files for Rocky 8/9

### DIFF
--- a/vars/Rocky_8.yml
+++ b/vars/Rocky_8.yml
@@ -1,0 +1,1 @@
+RedHat_8.yml

--- a/vars/Rocky_9.yml
+++ b/vars/Rocky_9.yml
@@ -1,0 +1,1 @@
+RedHat_9.yml


### PR DESCRIPTION
Currently no `vars` file is picked up in the task `ssh : Set platform/version specific variables` when running against `Rocky8` or `Rocky9`.
This is fixed by creating the softlinks:

```txt
Rocky_8.yml -> RedHat_8.yml
Rocky_9.yml -> RedHat_9.yml
``` 

Another approach would be to simplify `set_vars.yml` by doing somehting similar to `willshersystems.sshd`, the relevant code is here: <https://github.com/willshersystems/ansible-sshd/blob/master/tasks/variables.yml#L8-L33>. This would allow us to get rid of the many softlinks for RHEL derivatives.