### PR TITLE
ansible-lint - use changed_when for conditional tasks

### DIFF
--- a/tests/tests_user_config.yml
+++ b/tests/tests_user_config.yml
@@ -106,6 +106,7 @@
           when:
             - ansible_facts['distribution'] not in ['CentOS', 'RedHat'] or
               ansible_facts['distribution_version'] | int > 6
+          changed_when: false
 
         - name: Make sure the effective configuration is expected
           assert:


### PR DESCRIPTION
ansible-lint now requires the use of changed_when even for
conditional tasks

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
