### PR TITLE
ci: Remove Debian stretch (9)

### DIFF
--- a/.github/workflows/ansible-debian.yml
+++ b/.github/workflows/ansible-debian.yml
@@ -30,16 +30,3 @@ jobs:
           group: local
           hosts: localhost
           targets: "tests/tests_*.yml"
-
-  debian-stretch:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout PR
-        uses: actions/checkout@v3
-
-      - name: ansible check with debian stretch (9)
-        uses: roles-ansible/check-ansible-debian-stretch-action@master
-        with:
-          group: local
-          hosts: localhost
-          targets: "tests/tests_*.yml"


### PR DESCRIPTION
This debian version went EOL last year and now fails most of the time. Described in the following issue:

https://github.com/roles-ansible/check-ansible-debian-stretch-action/issues/2