### PR TITLE
docs: remove unused Dependencies section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ssh
+
 ![CI Testing](https://github.com/linux-system-roles/ssh/workflows/tox/badge.svg)
 [![CI Ubuntu](https://github.com/linux-system-roles/ssh/actions/workflows/ansible-ubuntu.yml/badge.svg)](https://github.com/linux-system-roles/ssh/actions/workflows/ansible-ubuntu.yml)
 [![CI Debian](https://github.com/linux-system-roles/ssh/actions/workflows/ansible-debian.yml/badge.svg)](https://github.com/linux-system-roles/ssh/actions/workflows/ansible-debian.yml)
@@ -10,10 +11,10 @@ An Ansible role for managing ssh clients configuration.
 This role should work on any system that provides openssh client and is
 supported by ansible. The role was tested on:
 
- * RHEL/CentOS 6, 7, 8, 9
- * Fedora
- * Debian
- * Ubuntu
+* RHEL/CentOS 6, 7, 8, 9
+* Fedora
+* Debian
+* Ubuntu
 
 ## Role Variables
 
@@ -21,14 +22,14 @@ By default, the role should not modify the system configuration and generate
 global `ssh_config` that matches OS default (the generated configuration does
 not keep comments and order of the options).
 
- * `ssh_user`:
+### ssh_user
 
 By default (`null`) the role will modify the global configuration for all
 users. Other values will be interpreted as a username and the role will
 modify per-user configuration stored under `~/.ssh/config` of the given user.
 The user needs to exist before invoking this role otherwise it will fail.
 
- * `ssh_skip_defaults`:
+### ssh_skip_defaults
 
 By default (`auto`), the role writes the system-wide configuration file
 `/etc/ssh/ssh_config` and keeps OS defaults defined there (*true*). This is
@@ -36,7 +37,7 @@ automatically disabled, when a drop-in configuration file is created
 (`ssh_drop_in_name!=null`) or when per-user configuration file is created
 (`ssh_user!=null`).
 
- * `ssh_drop_in_name`:
+### ssh_drop_in_name
 
 This defines the name for the drop-in configuration file to be placed in
 system-wide drop-in directory. The name is used in the template
@@ -49,41 +50,37 @@ The suggested format is `NN-name`, where `NN` is two-digit number used for
 sorting the and `name` is any descriptive name for the content or the owner
 of the file.
 
- * `ssh`:
+### ssh dict
 
 A dict containing configuration options and respective values. See example
 below.
 
- * `ssh_...`:
+* `ssh_...`:
 
 Simple variables consisting of the option name prefixed with `ssh_` can be
 used rather than a dict above. The simple variable overrides values in dict
 above.
 
- * `ssh_additional_packages`:
+### ssh_additional_packages
 
 This role automatically installs packages needed for most common use cases
 on given platform. If some additional packages need to be installed (for
 example `openssh-keysign` for host-based authentication), they can be specified
 in this variable.
 
- * `ssh_config_file`:
+### ssh_config_file
 
 The configuration file that will be written by this role. The default is
 defined by template `/etc/ssh/ssh_config.d/{name}.conf` if system has drop-in
 directory or `/etc/ssh/ssh_config` otherwise. If `ssh_user!=null`, the
 default is `~/.ssh/config`.
 
- * `ssh_config_owner`, `ssh_config_group`, `ssh_config_mode`:
+### ssh_config_owner, ssh_config_group, ssh_config_mode
 
 The owner, group and mode of the created configuration file. The files are
 owned by `root:root` with mode `0644` by default, unless
 `ssh_user!=null`. In that case, the mode is `0600` and owner and
 group are derived from username given in `ssh_user` variable.
-
-## Dependencies
-
-none
 
 ## Example Playbook
 
@@ -95,9 +92,10 @@ creates alias "example" for connecting to the example.com host as a user
 somebody. The last line disables X11 forwarding.
 
 ```yaml
-- hosts: all
+- name: Manage ssh clients
+  hosts: all
   tasks:
-  - name: "Configure ssh clients"
+  - name: Configure ssh clients
     include_role:
       name: linux-system-roles.ssh
     vars:
@@ -109,12 +107,12 @@ somebody. The last line disables X11 forwarding.
         ControlPath: ~/.ssh/.cm%C
         Match:
           - Condition: "final all"
-            GSSAPIAuthentication: yes
+            GSSAPIAuthentication: true
         Host:
           - Condition: example
             Hostname: example.com
             User: somebody
-      ssh_ForwardX11: no
+      ssh_ForwardX11: false
 ```
 
 More examples are in the [`examples/`](examples) directory.


### PR DESCRIPTION
remove unused Dependencies section in README - it is confusing
to users who look at the README, see the `Dependencies` section
that says `None`, and think that there are no dependencies for
the role, when the actual dependencies are listed in the
`Requirements` section which is not even near the `Dependencies`
section.  So consistently use the `Requirements` section and
get rid of the `Dependencies` section.

Fix some markdownlint and ansible-lint issues.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
