### PR TITLE
ci: Fix implicit octal value in main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   file:
     path: "{{ getent_passwd[ssh_user][4] }}/.ssh/"
     state: directory
-    mode: 0700
+    mode: "0700"
     owner: "{{ ssh_user }}"
     group: "{{ ssh_user }}"
   when:


### PR DESCRIPTION
Enhancement:

Reason: Forbidden implicit octal value "0700" was found on line 21.

Result: Updated to use explicit octal format for better readability and to adhere to linting standards.

Issue Tracker Tickets (Jira or BZ if any):na
