### PR TITLE
ci: Add ALP-Dolomite var file

### DIFF
--- a/vars/ALP-Dolomite.yml
+++ b/vars/ALP-Dolomite.yml
@@ -1,0 +1,8 @@
+---
+# This system supports drop in directory so defaults are adjusted
+__ssh_supports_drop_in: true
+__ssh_drop_in_name: "00-ansible"
+
+# This default lists the main configuration file defaults
+__ssh_defaults:
+  Include: /etc/ssh/ssh_config.d/*.conf


### PR DESCRIPTION
Enhancement: Add variables for additional operating system.

Reason: The existing configuration does not cover [SUSE ALP](https://documentation.suse.com/alp/dolomite/html/alp-dolomite/index.html), the default configurations are being used.

Result: Works as expected in the added operating system.

Issue Tracker Tickets (Jira or BZ if any):na