### PR TITLE
tests: Ensure backup/restore preserves file attributes

### DIFF
--- a/tests/tasks/backup.yml
+++ b/tests/tasks/backup.yml
@@ -14,7 +14,7 @@
   shell: >
     if test -f {{ item }}; then
       mkdir -p {{ __ssh_test_backup.path }}/$(dirname {{ item }});
-      cp {{ item }} {{ __ssh_test_backup.path }}/$(dirname {{ item }})
+      cp -a {{ item }} {{ __ssh_test_backup.path }}/$(dirname {{ item }})
     fi
   changed_when: false
   loop: "{{ __ssh_test_backup_files | d([]) }}"

--- a/tests/tasks/restore.yml
+++ b/tests/tasks/restore.yml
@@ -2,7 +2,7 @@
 - name: Restore backed up files and remove what was not present
   shell: >
     if test -f {{ __ssh_test_backup.path }}/{{ item }}; then
-      cp {{ __ssh_test_backup.path }}/{{ item }} $(dirname {{ item }})
+      cp -a {{ __ssh_test_backup.path }}/{{ item }} $(dirname {{ item }})
     elif test -f {{ item }}; then
       rm {{ item }}
     fi


### PR DESCRIPTION
I noticed some test failures in tests that check ownership/permissions
of config files.  The tests were recently changed to reuse the same
VM, so I suspect config files were not being backed up/restored with
the correct file attributes.  Use `cp -a` to preserve all file
attributes.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
