### PR TITLE
fix: Fix warning for using jinja templates in assert

### DIFF
--- a/tests/tests_additional_packages.yml
+++ b/tests/tests_additional_packages.yml
@@ -26,4 +26,4 @@
     - name: Verify the packages were installed
       assert:
         that:
-          - "'{{ additional_package | trim }}' in ansible_facts.packages"
+          - "additional_package | trim in ansible_facts.packages"

--- a/tests/tests_additional_packages.yml
+++ b/tests/tests_additional_packages.yml
@@ -26,4 +26,4 @@
     - name: Verify the packages were installed
       assert:
         that:
-          - "additional_package | trim in ansible_facts.packages"
+          - additional_package | trim in ansible_facts.packages

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -85,6 +85,6 @@
     - name: Verify the options are in the file
       assert:
         that:
-          - "item ~ ' yes' in config.content | b64decode "
+          - item ~ ' yes' in config.content | b64decode
       loop:
         "{{ ssh_options.stdout_lines }}"

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -85,6 +85,6 @@
     - name: Verify the options are in the file
       assert:
         that:
-          - "'{{ item }} yes' in config.content | b64decode "
+          - "item ~ ' yes' in config.content | b64decode "
       loop:
         "{{ ssh_options.stdout_lines }}"

--- a/tests/tests_no_skip_defaults.yml
+++ b/tests/tests_no_skip_defaults.yml
@@ -37,5 +37,5 @@
     - name: Check if the selected options are in
       assert:
         that:
-          - "'{{ __ssh_test_option | trim }}' in config.content | b64decode"
+          - "__ssh_test_option | trim in config.content | b64decode"
           - "'LocalForward 2222 localhost:22' in config.content | b64decode"


### PR DESCRIPTION
Enhancement: Fix wrong assert in test

Reason: The assert was wrong causing warning and test failures on Debian

Result: The assert was fixed

Issue Tracker Tickets (Jira or BZ if any): -