### PR TITLE
ci: use tox-lsr 3.3.0 which uses ansible-test 2.17

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
 
       - name: Convert role to collection format
         run: |


### PR DESCRIPTION
Upgrade ci tests to use tox-lsr 3.3.0

tox-lsr 3.3.0 uses ansible-test 2.17

Create the ansible-test ignore file for 2.17

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
