### PR TITLE
test: Add temporary solution for broken ubuntu-latest action

### DIFF
--- a/.github/workflows/ansible-centos.yml
+++ b/.github/workflows/ansible-centos.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ansible check with centos 8
-        uses: roles-ansible/check-ansible-centos-centos8-action@master
+        uses: Jakuje/check-ansible-centos-centos8-action@master
         with:
           group: local
           hosts: localhost

--- a/.github/workflows/ansible-ubuntu.yml
+++ b/.github/workflows/ansible-ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ansible check with ubuntu:latest
-        uses: roles-ansible/check-ansible-ubuntu-latest-action@master
+        uses: mattwillsher/check-ansible-ubuntu-latest-action@master
         with:
           group: local
           hosts: localhost


### PR DESCRIPTION
Enhancement: Fix CI for Ubuntu 24.04

Reason: The new ubuntu was released breaking the action

Result: The CI should run (and work) again.

Issue Tracker Tickets (Jira or BZ if any): -