### PR TITLE
fix: add support for EL10

### DIFF
--- a/.ostree/packages-testing-CentOS-10.txt
+++ b/.ostree/packages-testing-CentOS-10.txt
@@ -1,0 +1,1 @@
+packages-testing-RedHat-10.txt

--- a/.ostree/packages-testing-CentOS-7.txt
+++ b/.ostree/packages-testing-CentOS-7.txt
@@ -1,3 +1,1 @@
-bash
-man-db
-openssh-ldap
+packages-testing-RedHat-7.txt

--- a/.ostree/packages-testing-CentOS-8.txt
+++ b/.ostree/packages-testing-CentOS-8.txt
@@ -1,3 +1,1 @@
-bash
-man-db
-openssh-ldap
+packages-testing-RedHat-8.txt

--- a/.ostree/packages-testing-CentOS-9.txt
+++ b/.ostree/packages-testing-CentOS-9.txt
@@ -1,3 +1,1 @@
-bash
-man-db
-openssh-keycat
+packages-testing-RedHat-9.txt

--- a/.ostree/packages-testing-RedHat-10.txt
+++ b/.ostree/packages-testing-RedHat-10.txt
@@ -1,0 +1,3 @@
+bash
+man-db
+openssh-keycat

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,26 +17,40 @@ galaxy_info:
         - all
     - name: Debian
       versions:
-        - wheezy
-        - jessie
-        - stretch
-        - buster
+        - "wheezy"
+        - "jessie"
+        - "stretch"
+        - "buster"
     - name: Ubuntu
       versions:
-        - precise
-        - trusty
-        - xenial
-        - bionic
-        - focal
-        - jammy
+        - "precise"
+        - "trusty"
+        - "xenial"
+        - "bionic"
+        - "focal"
+        - "jammy"
   galaxy_tags:
-    - networking
-    - system
-    - ssh
-    - client
-    - openssh
-    - ubuntu
-    - debian
     - centos
+    - client
+    - debianbuster
+    - debianjessie
+    - debianstretch
+    - debianwheezy
+    - el6
+    - el7
+    - el8
+    - el9
+    - el10
+    - fedora
+    - networking
+    - openssh
     - redhat
+    - ssh
+    - system
+    - ubuntubionic
+    - ubuntufocal
+    - ubuntujammy
+    - ubuntuprecise
+    - ubuntutrusty
+    - ubuntuxenial
 dependencies: []

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -1,0 +1,1 @@
+RedHat_10.yml

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,0 +1,8 @@
+---
+# This system supports drop in directory so defaults are adjusted
+__ssh_supports_drop_in: true
+__ssh_drop_in_name: "00-ansible"
+
+# This default lists the main configuration file defaults
+__ssh_defaults:
+  Include: /etc/ssh/ssh_config.d/*.conf


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
