### PR TITLE
fix: Workaround for CentOS 10 issues in openssh

### DIFF
--- a/.github/workflows/ansible-centos.yml
+++ b/.github/workflows/ansible-centos.yml
@@ -44,3 +44,16 @@ jobs:
           group: local
           hosts: localhost
           targets: "tests/tests_*.yml"
+
+  centos-10:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout PR
+        uses: actions/checkout@v4
+
+      - name: ansible check with centos 10
+        uses: roles-ansible/check-ansible-centos-centos10-action@main
+        with:
+          group: local
+          hosts: localhost
+          targets: "tests/tests_*.yml"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Ansible role for managing ssh clients configuration.
 This role should work on any system that provides openssh client and is
 supported by ansible. The role was tested on:
 
-* RHEL/CentOS 6, 7, 8, 9
+* RHEL/CentOS 6, 7, 8, 9, 10
 * Fedora
 * Debian
 * Ubuntu

--- a/tests/tests_match.yml
+++ b/tests/tests_match.yml
@@ -19,7 +19,7 @@
         ssh:
           Match:
             - Condition: user testuser
-              Compression: true
+              LogLevel: DEBUG2
             - Condition: host example
               Hostname: example.com
           Host:
@@ -39,7 +39,7 @@
           assert:
             that:
               - "'Match user testuser' in config.content | b64decode"
-              - "'Compression yes' in config.content | b64decode"
+              - "'LogLevel DEBUG2' in config.content | b64decode"
               - "'Match host example' in config.content | b64decode"
               - "'Hostname example.com' in config.content | b64decode"
               - "'Host local' in config.content | b64decode"
@@ -70,9 +70,9 @@
         - name: Verify the options are correctly evaluated
           assert:
             that:
-              - "'compression yes' in test1.stdout"
-              - "'compression yes' not in test2.stdout"
-              - "'compression yes' not in test3.stdout"
+              - "'loglevel DEBUG2' in test1.stdout"
+              - "'loglevel DEBUG2' not in test2.stdout"
+              - "'loglevel DEBUG2' not in test3.stdout"
               - "'hostname example.com' in test1.stdout"
               - "'hostname example.com' not in test2.stdout"
               - "'hostname example.com' not in test3.stdout"


### PR DESCRIPTION
Enhancement: Fix tests in CentOS 10 and add GH based tests to CI

Reason: The OpenSSH broke parsing of Compression option

Result: The tests were failing

Issue Tracker Tickets (Jira or BZ if any): RHEL-68346