### PR TITLE
tests: Add missing dependency on Fedora 42

### DIFF
--- a/.ostree/packages-testing-Fedora.txt
+++ b/.ostree/packages-testing-Fedora.txt
@@ -1,3 +1,1 @@
-bash
-man-db
 openssh-keycat

--- a/.ostree/packages-testing-RedHat-10.txt
+++ b/.ostree/packages-testing-RedHat-10.txt
@@ -1,3 +1,1 @@
-bash
-man-db
 openssh-keycat

--- a/.ostree/packages-testing-RedHat-7.txt
+++ b/.ostree/packages-testing-RedHat-7.txt
@@ -1,3 +1,1 @@
-bash
-man-db
 openssh-ldap

--- a/.ostree/packages-testing-RedHat-8.txt
+++ b/.ostree/packages-testing-RedHat-8.txt
@@ -1,3 +1,1 @@
-bash
-man-db
 openssh-ldap

--- a/.ostree/packages-testing-RedHat-9.txt
+++ b/.ostree/packages-testing-RedHat-9.txt
@@ -1,3 +1,1 @@
-bash
-man-db
 openssh-keycat

--- a/.ostree/packages-testing.txt
+++ b/.ostree/packages-testing.txt
@@ -1,0 +1,3 @@
+bash
+gawk
+man-db

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -53,11 +53,12 @@
         - not __ssh_is_ostree | bool
       changed_when: true
 
-    - name: Make sure manual pages and bash are installed
+    - name: Make sure manual pages, gawk and bash are installed
       package:
         name:
           - "{{ (ansible_facts['os_family'] == 'RedHat') |
                 ternary('man-db', 'man') }}"
+          - gawk
           - bash
           - "{{ ssh_test_package }}"
         state: present


### PR DESCRIPTION
Enhancement: Add missing dependency

Reason: Fedora removed awk from the minimal containers, which caused some tests to fail.

Result: Added awk installation to the test. 

Issue Tracker Tickets (Jira or BZ if any): -
