### PR TITLE
feat: Support this role in container environments and builds

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -53,4 +53,6 @@ galaxy_info:
     - ubuntuprecise
     - ubuntutrusty
     - ubuntuxenial
+    - container
+    - containerbuild
 dependencies: []

--- a/tests/tests_user_config.yml
+++ b/tests/tests_user_config.yml
@@ -100,10 +100,9 @@
               - config_mode.stat.mode == '0600'
 
         - name: Test the effective configuration using ssh
-          become: true
-          become_user: "{{ username }}"
-          become_method: "{{ __become_method }}"
-          command: ssh -vvv -G example
+          # don't use become_user, does not work in containers due to
+          # https://github.com/linux-system-roles/tox-lsr/pull/191
+          command: "su -c 'ssh -vvv -G example' {{ username }}"
           register: effective
           when:
             - ansible_facts['distribution'] not in ['CentOS', 'RedHat'] or


### PR DESCRIPTION
Feature: Support running the ssh role during container builds and in container environments.

Reason: This is particularly useful for building bootc derivative OSes. It's also desirable to run roles in system containers.

Result: These flags enable running the container scenarios in CI, which ensures that the role works in podman system containers as well as buildah build environment and thus allows us to officially support this role for image mode builds.

See https://issues.redhat.com/browse/RHEL-78157

## Summary by Sourcery

Enable SSH role support in container build and runtime environments by updating supported platforms in metadata and adapting tests to work inside containers.

New Features:
- Add 'container' and 'containerbuild' as supported platforms in role metadata

Tests:
- Update SSH configuration test to use 'su -c' instead of become_user for compatibility with container environments