### PR TITLE
tests: Update tests_all_options.yml to do bootc end-to-end validation

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,6 +32,8 @@ galaxy_info:
   galaxy_tags:
     - centos
     - client
+    - container
+    - containerbuild
     - debianbuster
     - debianjessie
     - debianstretch
@@ -53,6 +55,4 @@ galaxy_info:
     - ubuntuprecise
     - ubuntutrusty
     - ubuntuxenial
-    - container
-    - containerbuild
 dependencies: []

--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -94,13 +94,20 @@
         name: linux-system-roles.ssh
       vars:
         __ssh_supports_validate: false
-        ssh_config_file: /tmp/ssh_config
+        ssh_config_file: /etc/test_ssh_config
         ssh:
           "{{ ssh_c }}"
+      when: not __bootc_validation | d(false)
+
+    - name: Create QEMU deployment during bootc end-to-end test
+      delegate_to: localhost
+      command: "{{ lsr_scriptdir }}/bootc-buildah-qcow.sh {{ ansible_host }}"
+      changed_when: true
+      when: ansible_connection == "buildah"
 
     - name: Download the configuration file
       slurp:
-        src: /tmp/ssh_config
+        src: /etc/test_ssh_config
       register: config
 
     - name: Verify the options are in the file


### PR DESCRIPTION
Move the generated file to /etc, as files in /tmp don't get included in a bootc deployment.
    
See https://issues.redhat.com/browse/RHEL-78157

## Summary by Sourcery

Enable bootc end-to-end validation by relocating generated test files, guarding tasks with __bootc_validation, adding a QEMU deployment step, and updating metadata tags.

New Features:
- Add a step to create a QEMU deployment via bootc-buildah-qcow.sh for buildah connections.

Enhancements:
- Move SSH config file path from /tmp to /etc/test_ssh_config and guard relevant tasks with the __bootc_validation flag.
- Reorder and deduplicate container and containerbuild tags in meta/main.yml.