### PR TITLE
fix: Avoid setting ansible_managed variable

### DIFF
--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"


### PR DESCRIPTION
Cause: The test used a temporary variable `ansible_managed`, but that is a "magic" string constant. Ansible 2.19 does not permit assigning to it any more.

Consequence: Tests failed with Ansible 2.19.

Fix: Rename the variable.

---

This should fix the [F42/ansible 2.19 failure](https://github.com/linux-system-roles/ssh/actions/runs/15539439136/job/43746425705) introduced in #188

## Summary by Sourcery

Bug Fixes:
- Fix test failure on Ansible 2.19 by renaming the temporary ansible_managed variable to __ansible_managed.