### PR TITLE
ci: fix markdown formatting for contributing.md to pass markdownlint

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -74,6 +74,7 @@ To run the tests locally in container, you can use the attached Containerfile
 podman build -t system-roles-ssh .dev-tools
 podman run -itv ./:/src:Z system-roles-ssh
 ```
+
 ## Running CI Tests Locally
 
 ### Use tox-lsr with qemu


### PR DESCRIPTION
fix markdown formatting for contributing.md to pass markdownlint

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Documentation:
- Add a missing blank line before the 'Running CI Tests Locally' heading to comply with markdownlint.