### PR TITLE
test: only reinstall openssh-clients if necessary

### DIFF
--- a/tests/tests_all_options.yml
+++ b/tests/tests_all_options.yml
@@ -43,12 +43,14 @@
           if ansible_facts['distribution_version'] | int > 7
           else '/etc/yum.conf' }}"
         state: absent
+      register: __ssh_nodocs
       when:
         - ansible_facts['os_family'] == "RedHat"
 
     - name: Reinstall manual pages for openssh-clients on RHEL
       ansible.builtin.command: "{{ pkg_mgr }} reinstall -y openssh-clients"
       when:
+        - __ssh_nodocs is changed
         - ansible_facts['os_family'] == "RedHat"
         - not __ssh_is_ostree | bool
       changed_when: true


### PR DESCRIPTION
Do not attempt to reinstall openssh-clients to get the docs
if already configured to install the docs.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Register the manual page removal result in __ssh_nodocs and conditionally reinstall openssh-clients only if docs were actually removed