### PR TITLE
ci: tox-lsr 3.16.0 - fix qemu tox test failures - rename to qemu-ansible-core-X-Y [citest_skip]

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.15.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.16.0"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.15.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.16.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.15.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.16.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -28,22 +28,22 @@ jobs:
       matrix:
         scenario:
           # QEMU
-          - { image: "centos-9", env: "qemu-ansible-core-2.16" }
-          - { image: "centos-10", env: "qemu-ansible-core-2.17" }
-          - { image: "fedora-42", env: "qemu-ansible-core-2.19" }
-          - { image: "fedora-43", env: "qemu-ansible-core-2.19" }
-          - { image: "leap-15.6", env: "qemu-ansible-core-2.18" }
+          - { image: "centos-9", env: "qemu-ansible-core-2-16" }
+          - { image: "centos-10", env: "qemu-ansible-core-2-17" }
+          - { image: "fedora-42", env: "qemu-ansible-core-2-19" }
+          - { image: "fedora-43", env: "qemu-ansible-core-2-19" }
+          - { image: "leap-15.6", env: "qemu-ansible-core-2-18" }
 
           # container
-          - { image: "centos-9", env: "container-ansible-core-2.16" }
-          - { image: "centos-9-bootc", env: "container-ansible-core-2.16" }
+          - { image: "centos-9", env: "container-ansible-core-2-16" }
+          - { image: "centos-9-bootc", env: "container-ansible-core-2-16" }
           # broken on non-running dbus
-          # - { image: "centos-10", env: "container-ansible-core-2.17" }
-          - { image: "centos-10-bootc", env: "container-ansible-core-2.17" }
-          - { image: "fedora-42", env: "container-ansible-core-2.17" }
-          - { image: "fedora-43", env: "container-ansible-core-2.19" }
-          - { image: "fedora-42-bootc", env: "container-ansible-core-2.17" }
-          - { image: "fedora-43-bootc", env: "container-ansible-core-2.19" }
+          # - { image: "centos-10", env: "container-ansible-core-2-17" }
+          - { image: "centos-10-bootc", env: "container-ansible-core-2-17" }
+          - { image: "fedora-42", env: "container-ansible-core-2-17" }
+          - { image: "fedora-43", env: "container-ansible-core-2-19" }
+          - { image: "fedora-42-bootc", env: "container-ansible-core-2-17" }
+          - { image: "fedora-43-bootc", env: "container-ansible-core-2-19" }
 
     env:
       TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
@@ -110,7 +110,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.15.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.16.0"
 
       # HACK: Drop this when moving this workflow to 26.04 LTS
       - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5

--- a/contributing.md
+++ b/contributing.md
@@ -109,7 +109,7 @@ The latest version of tox-lsr supports qemu testing.
    you can use e.g.
 
    ```bash
-   tox -e qemu-ansible-core-2.14 -- --image-name centos-9 tests/tests_default.yml
+   tox -e qemu-ansible-core-2-20 -- --image-name centos-9 tests/tests_default.yml
    ```
 
 There are many command line options and environment variables which can be used


### PR DESCRIPTION
the latest version of tox 4.49 has a strange issue - it thinks that a tox testenv
like `[qemu-ansible-core-2.20]` is specifying python 2.20 which conflicts with the
testenv basepython of python 3.latest.  There appears to be no way to workaround this.

So, rename all of the testenvs to use `major-minor` instead of `major.minor` e.g.
`[qemu-ansible-core-2-20]`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update CI workflows and documentation to use tox-lsr 3.16.0 and the new qemu/container ansible-core environment naming scheme.

CI:
- Bump tox-lsr version from 3.15.0 to 3.16.0 across GitHub Actions workflows.
- Adjust qemu and container ansible-core matrix environment names in qemu-kvm integration tests to use dash-separated major-minor versions instead of dotted versions.

Documentation:
- Update contributing guide example to use the new dash-separated qemu ansible-core tox environment name.