### PR TITLE
ci: tox-lsr 3.17.1 - previous update broke container tests, this fixes them [citest_skip]

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.17.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.17.1"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.17.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.17.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.17.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.17.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -75,7 +75,7 @@ jobs:
 
           # bootc build support (in buildah) has a separate flag
           if [ "${{ matrix.scenario.image }}" != "$image" ]; then
-          if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
+            if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
               supported=
             fi
           else
@@ -110,7 +110,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.17.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.17.1"
 
       # HACK: Drop this when moving this workflow to 26.04 LTS
       - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5
@@ -178,7 +178,6 @@ jobs:
           rc=0
           # we cannot skip these on the first test
           export SKIP_REQUIREMENTS=false
-          export SKIP_CALLBACK_PLUGINS=false
           for t in tests/tests_*.yml; do
               if tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} $t > ${t}.log 2>&1; then
                   echo "PASS: $(basename $t)"
@@ -190,7 +189,6 @@ jobs:
               fi
               # we can skip these on subsequent runs
               export SKIP_REQUIREMENTS=true
-              export SKIP_CALLBACK_PLUGINS=true
           done
           exit $rc
 


### PR DESCRIPTION
tox-lsr 3.17.1 has a fix for the broken container tests

There was one shell function for both setting up the callback plugins and the connection plugin.
When this function was skipped, the ANSIBLE_CONNECTION_PLUGINS environment variable was not
set, so all subsequent tests failed.  The connection plugin must be present and the env. var.
must be set in order to run any container tests.  The code was fixed to ensure that there is
always a connection plugin installed in the correct location and that ANSIBLE_CONNECTION_PLUGINS
is always set and contains this path.

Also, setting up the callback plugins and the connection plugin is already idempotent, so no
reason to skip them.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
