### PR TITLE
ci: bump tox-lsr version to 3.20.0 to fix tox 4.58 api breakage [citest_skip]

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -110,7 +110,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
 
       # HACK: Drop this when moving this workflow to 26.04 LTS
       - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5


### PR DESCRIPTION
This fixes the tox-lsr related test failures in ansible-lint, et. al. caused
by an internal tox api change in version 4.58

See https://github.com/linux-system-roles/tox-lsr/pull/245 for more info

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
